### PR TITLE
Add ETSHub Kubernetes deployment

### DIFF
--- a/apps/etshub/base/deployment.yaml
+++ b/apps/etshub/base/deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: etshub
+  annotations:
+    kube-score/ignore: pod-networkpolicy,container-image-tag
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: etshub
+  template:
+    metadata:
+      labels:
+        app: etshub
+    spec:
+      imagePullSecrets:
+        - name: ghcr-clubcedille-secret
+      containers:
+        - name: etshub
+          image: ghcr.io/clubcedille/etshub:latest
+          imagePullPolicy: Always
+          env:
+            - name: RESEND_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: etshub-secret
+                  key: RESEND_API_KEY
+                  optional: true
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+          ports:
+            - containerPort: 3000
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+              ephemeral-storage: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+              ephemeral-storage: 1Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 1001
+            runAsGroup: 1001
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault

--- a/apps/etshub/base/deployment.yaml
+++ b/apps/etshub/base/deployment.yaml
@@ -14,8 +14,14 @@ spec:
       labels:
         app: etshub
     spec:
+      securityContext:
+        fsGroup: 10001
+        fsGroupChangePolicy: OnRootMismatch
       imagePullSecrets:
         - name: ghcr-clubcedille-secret
+      volumes:
+        - name: tmp
+          emptyDir: {}
       containers:
         - name: etshub
           image: ghcr.io/clubcedille/etshub:latest
@@ -36,11 +42,14 @@ spec:
             timeoutSeconds: 5
           livenessProbe:
             httpGet:
-              path: /
+              path: /manifest.webmanifest
               port: 3000
             initialDelaySeconds: 30
             periodSeconds: 30
             timeoutSeconds: 5
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
           ports:
             - containerPort: 3000
           resources:
@@ -54,10 +63,10 @@ spec:
               ephemeral-storage: 1Gi
           securityContext:
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: false
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
-            runAsUser: 1001
-            runAsGroup: 1001
+            runAsUser: 10001
+            runAsGroup: 10001
             capabilities:
               drop:
                 - ALL

--- a/apps/etshub/base/kustomization.yaml
+++ b/apps/etshub/base/kustomization.yaml
@@ -2,4 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- argoapps.yml
+  - deployment.yaml
+  - service.yaml

--- a/apps/etshub/base/service.yaml
+++ b/apps/etshub/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: etshub-svc
+spec:
+  selector:
+    app: etshub
+  ports:
+    - name: http
+      port: 80
+      targetPort: 3000

--- a/apps/etshub/etshub.argoapp.yaml
+++ b/apps/etshub/etshub.argoapp.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: etshub
+  namespace: argocd
+  annotations:
+    argocd-image-updater.argoproj.io/image-list: etshub=ghcr.io/clubcedille/etshub:latest
+    argocd-image-updater.argoproj.io/etshub.update-strategy: digest
+    argocd-image-updater.argoproj.io/etshub.pull-secret: pullsecret:argocd/ghcr-clubcedille-secret
+spec:
+  project: k8s-cedille-production-v2
+  destination:
+    server: https://cedille.kubernetes.omni.siderolabs.io?cluster=k8s-cedille-production-v2
+    namespace: etshub
+  source:
+    repoURL: https://github.com/ClubCedille/k8s-cedille-production-v2
+    path: apps/etshub/prod
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      selfHeal: true
+      prune: true

--- a/apps/etshub/prod/ingress.yaml
+++ b/apps/etshub/prod/ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: etshub
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-http
+    ingress.kubernetes.io/force-ssl-redirect: "true"
+    kubernetes.io/tls-acme: "true"
+spec:
+  ingressClassName: contour
+  tls:
+    - secretName: etshub-tls
+      hosts:
+        - etshub.prodv2.cedille.club
+  rules:
+    - host: etshub.prodv2.cedille.club
+      http:
+        paths:
+          - pathType: Prefix
+            path: /
+            backend:
+              service:
+                name: etshub-svc
+                port:
+                  number: 80

--- a/apps/etshub/prod/kustomization.yaml
+++ b/apps/etshub/prod/kustomization.yaml
@@ -2,4 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- argoapps.yml
+  - ../base/
+  - ingress.yaml

--- a/kustomization.yml
+++ b/kustomization.yml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- argoapps.yml
+  - argoapps.yml

--- a/kustomization.yml
+++ b/kustomization.yml
@@ -1,5 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-
-resources:
-  - argoapps.yml


### PR DESCRIPTION
**Décrire le pull-request**

Ajoute le déploiement Kubernetes/ArgoCD pour ETSHub dans le cluster production v2.

Le déploiement utilise l’image `ghcr.io/clubcedille/etshub:latest`, avec ArgoCD Image Updater configuré et le pull secret GHCR `ghcr-clubcedille-secret`.

La variable `RESEND_API_KEY` est configurée comme secret optionnel via `etshub-secret`. elle pourra être ajoutée après le premier sync pour activer le formulaire de contact.

Correction aussi de `kustomization.yml` racine pour qu’il pointe vers le fichier existant `argoapps.yml`  ?? (´。＿。｀)

**Vérification**

Veuillez cocher les cases suivantes pour confirmer que vous avez effectué les vérifications nécessaires avant de soumettre le pull-request :

- [x] J'ai vérifié que le code fonctionne correctement.
- [x] J'ai vérifié que le code respecte l'architecture du projet.

**Documentation**

- [x] J'ai mis à jour la documentation si nécessaire sinon j'ai ouvert un issue pour la mettre à jour.