### PR TITLE
feat/PLANIFETS-098 Dev & Staging Environments for PlanifETS

### DIFF
--- a/apps/applets/planifets-chatbot/README.md
+++ b/apps/applets/planifets-chatbot/README.md
@@ -1,0 +1,75 @@
+# planifets-chatbot
+
+Applet GitOps pour le composant `planifets-chatbot` déployé sur le cluster `k8s-cedille-production-v2` via ArgoCD.
+
+Ce dossier ne contient plus une stack frontend/backend complète : il gère uniquement le service **Qdrant** utilisé par le chatbot, avec les secrets associés par environnement.
+
+## Ce qui est déployé
+
+| Composant | Image | Port | Rôle |
+|-----------|-------|------|------|
+| Qdrant | `qdrant/qdrant:latest` | `6333` / `6334` | Base vectorielle du chatbot |
+
+## Environnements
+
+| Env | Namespace | ArgoCD Application | Secret Vault |
+|-----|-----------|--------------------|--------------|
+| dev | `planifets-chatbot-dev` | `planifets-chatbot-dev` | `kv/data/planifets-chatbot/dev/planifets-chatbot/qdrant` |
+| staging | `planifets-chatbot-staging` | `planifets-chatbot-staging` | `kv/data/planifets-chatbot/staging/planifets-chatbot/qdrant` |
+| prod | `planifets-chatbot` | `planifets-chatbot` | `kv/data/planifets-chatbot/default/planifets-chatbot/qdrant` |
+
+## Structure actuelle
+
+```text
+apps/applets/planifets-chatbot/
+├── planifets-chatbot.argoapp.yaml   # 3 Applications ArgoCD : dev, staging, prod
+├── base/
+│   └── qdrant/
+│       ├── service.yaml             # Service ClusterIP (6333/6334)
+│       └── statefulset.yaml         # StatefulSet Qdrant + PVC
+├── dev/
+│   ├── kustomization.yaml           # Base qdrant + secret Vault dev
+│   └── vault-secret.yaml
+├── staging/
+│   ├── kustomization.yaml           # Base qdrant + secret Vault staging
+│   └── vault-secret.yaml
+└── prod/
+    ├── kustomization.yaml           # Base qdrant + secret Vault prod
+    └── vault-secret.yaml
+```
+
+## Secrets Vault
+
+Les secrets sont gérés via **HashiCorp Vault** et l'opérateur `vault-secret`.
+
+Chaque environnement crée un secret Kubernetes `planifets-chatbot-secret` contenant la clé `qdrant_api_key`, lue par le StatefulSet via `QDRANT__SERVICE__API_KEY`.
+
+### Chemins Vault attendus
+
+- `dev` → `kv/data/planifets-chatbot/dev/planifets-chatbot/qdrant`
+- `staging` → `kv/data/planifets-chatbot/staging/planifets-chatbot/qdrant`
+- `prod` → `kv/data/planifets-chatbot/default/planifets-chatbot/qdrant`
+
+## Déploiement
+
+1. Créer ou mettre à jour la valeur `api_key` dans le chemin Vault de l'environnement visé.
+2. Laisser ArgoCD synchroniser l'application correspondante.
+3. Vérifier que le secret `planifets-chatbot-secret` et le StatefulSet Qdrant sont bien présents dans le namespace.
+
+### Vérifications utiles
+
+```bash
+kubectl get pods -n planifets-chatbot-dev
+kubectl get pods -n planifets-chatbot-staging
+kubectl get pods -n planifets-chatbot
+
+kubectl get secret -n planifets-chatbot-dev planifets-chatbot-secret
+kubectl get statefulset -n planifets-chatbot-dev planifets-chatbot-qdrant
+kubectl get svc -n planifets-chatbot-dev planifets-chatbot-qdrant
+```
+
+## Notes
+
+- Le stockage persistant Qdrant utilise un `volumeClaimTemplate` de `5Gi` avec `storageClassName: cephfs`.
+- Le service expose les ports `6333` (HTTP) et `6334` (gRPC).
+- Les trois overlays (`dev`, `staging`, `prod`) réutilisent la base `qdrant` et ne diffèrent que par leur secret Vault.

--- a/apps/applets/planifets-chatbot/base/qdrant/kustomization.yaml
+++ b/apps/applets/planifets-chatbot/base/qdrant/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - statefulset.yaml
+  - service.yaml

--- a/apps/applets/planifets-chatbot/base/qdrant/service.yaml
+++ b/apps/applets/planifets-chatbot/base/qdrant/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: planifets-chatbot-qdrant
+spec:
+  selector:
+    app: planifets-chatbot-qdrant
+  clusterIP: None
+  ports:
+    - name: http
+      protocol: TCP
+      port: 6333
+      targetPort: 6333
+    - name: grpc
+      protocol: TCP
+      port: 6334
+      targetPort: 6334
+  type: ClusterIP

--- a/apps/applets/planifets-chatbot/base/qdrant/service.yaml
+++ b/apps/applets/planifets-chatbot/base/qdrant/service.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: planifets-chatbot-qdrant
+  annotations:
+    kube-score/ignore: pod-networkpolicy, service-targets-pod
 spec:
   selector:
     app: planifets-chatbot-qdrant

--- a/apps/applets/planifets-chatbot/base/qdrant/statefulset.yaml
+++ b/apps/applets/planifets-chatbot/base/qdrant/statefulset.yaml
@@ -1,0 +1,75 @@
+piVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: planifets-chatbot-qdrant
+  annotations:
+    kube-score/ignore: pod-networkpolicy, pod-probes, container-image-tag
+spec:
+  serviceName: planifets-chatbot-qdrant
+  replicas: 1
+  selector:
+    matchLabels:
+      app: planifets-chatbot-qdrant
+  template:
+    metadata:
+      labels:
+        app: planifets-chatbot-qdrant
+    spec:
+      securityContext:
+        fsGroup: 10001
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      containers:
+        - name: qdrant
+          image: qdrant/qdrant:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 6333
+              name: http
+            - containerPort: 6334
+              name: grpc
+          env:
+            - name: QDRANT__SERVICE__API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: planifets-chatbot-secret
+                  key: qdrant_api_key
+          livenessProbe:
+            tcpSocket:
+              port: 6333
+            initialDelaySeconds: 30
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 6333
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 200m
+              memory: 256Mi
+              ephemeral-storage: 256Mi
+            limits:
+              cpu: 800m
+              memory: 1Gi
+              ephemeral-storage: 1Gi
+          securityContext:
+            runAsUser: 10001
+            runAsGroup: 10001
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: qdrant-storage
+              mountPath: /qdrant/storage
+            - name: tmp
+              mountPath: /tmp
+  volumeClaimTemplates:
+    - metadata:
+        name: qdrant-storage
+      spec:
+        accessModes: ["ReadWriteMany"] # for future growth and scaling
+        storageClassName: cephfs
+        resources:
+          requests:
+            storage: 5Gi

--- a/apps/applets/planifets-chatbot/dev/kustomization.yaml
+++ b/apps/applets/planifets-chatbot/dev/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base/qdrant
+  - vault-secret.yaml

--- a/apps/applets/planifets-chatbot/dev/vault-secret.yaml
+++ b/apps/applets/planifets-chatbot/dev/vault-secret.yaml
@@ -1,0 +1,19 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: VaultSecret
+metadata:
+  name: planifets-chatbot-secret
+spec:
+  refreshPeriod: 1h
+  vaultSecretDefinitions:
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: qdrant
+      path: kv/data/planifets-dev/default/chatbot/qdrant
+  output:
+    name: planifets-chatbot-secret
+    stringData:
+      qdrant_api_key: '{{ .qdrant.api_key }}'
+    type: opaque

--- a/apps/applets/planifets-chatbot/planifets-chatbot.argoapp.yaml
+++ b/apps/applets/planifets-chatbot/planifets-chatbot.argoapp.yaml
@@ -1,21 +1,18 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: planifets
+  name: planifets-chatbot
   namespace: argocd
   annotations:
     argocd.argoproj.io/sync-wave: "2"
-    argocd-image-updater.argoproj.io/image-list: website=ghcr.io/applets/planifets-frontend:latest, backend=ghcr.io/applets/planifets-backend:latest
-    argocd-image-updater.argoproj.io/website.update-strategy: digest
-    argocd-image-updater.argoproj.io/backend.update-strategy: digest
 spec:
-  project: k8s-cedille-production-v2
+  project: applets
   destination:
     server: https://cedille.kubernetes.omni.siderolabs.io?cluster=k8s-cedille-production-v2
     namespace: planifets
   source:
     repoURL: https://github.com/ClubCedille/k8s-cedille-production-v2
-    path: apps/applets/planifets/prod
+    path: apps/applets/planifets-chatbot/prod
     targetRevision: HEAD
   syncPolicy:
     syncOptions:
@@ -25,13 +22,10 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: planifets-staging
+  name: planifets-chatbot-staging
   namespace: argocd
   annotations:
     argocd.argoproj.io/sync-wave: "2"
-    argocd-image-updater.argoproj.io/image-list: website=ghcr.io/applets/planifets-frontend:staging, backend=ghcr.io/applets/planifets-backend:staging
-    argocd-image-updater.argoproj.io/website.update-strategy: digest
-    argocd-image-updater.argoproj.io/backend.update-strategy: digest
 spec:
   project: applets
   destination:
@@ -39,7 +33,7 @@ spec:
     namespace: planifets-staging
   source:
     repoURL: https://github.com/ClubCedille/k8s-cedille-production-v2
-    path: apps/applets/planifets/staging
+    path: apps/applets/planifets-chatbot/staging
     targetRevision: HEAD
   syncPolicy:
     syncOptions:
@@ -49,21 +43,18 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: planifets-dev
+  name: planifets-chatbot-dev
   namespace: argocd
   annotations:
     argocd.argoproj.io/sync-wave: "2"
-    argocd-image-updater.argoproj.io/image-list: website=ghcr.io/applets/planifets-frontend:dev, backend=ghcr.io/applets/planifets-backend:dev
-    argocd-image-updater.argoproj.io/website.update-strategy: digest
-    argocd-image-updater.argoproj.io/backend.update-strategy: digest
 spec:
-  project: applets
+  project: k8s-cedille-production-v2
   destination:
     server: https://cedille.kubernetes.omni.siderolabs.io?cluster=k8s-cedille-production-v2
     namespace: planifets-dev
   source:
     repoURL: https://github.com/ClubCedille/k8s-cedille-production-v2
-    path: apps/applets/planifets/dev
+    path: apps/applets/planifets-chatbot/dev
     targetRevision: HEAD
   syncPolicy:
     syncOptions:

--- a/apps/applets/planifets-chatbot/planifets-chatbot.argoapp.yaml
+++ b/apps/applets/planifets-chatbot/planifets-chatbot.argoapp.yaml
@@ -1,27 +1,6 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: planifets-chatbot
-  namespace: argocd
-  annotations:
-    argocd.argoproj.io/sync-wave: "2"
-spec:
-  project: applets
-  destination:
-    server: https://cedille.kubernetes.omni.siderolabs.io?cluster=k8s-cedille-production-v2
-    namespace: planifets
-  source:
-    repoURL: https://github.com/ClubCedille/k8s-cedille-production-v2
-    path: apps/applets/planifets-chatbot/prod
-    targetRevision: HEAD
-  syncPolicy:
-    syncOptions:
-      - CreateNamespace=true
-      - PruneLast=true
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
   name: planifets-chatbot-staging
   namespace: argocd
   annotations:

--- a/apps/applets/planifets-chatbot/staging/kustomization.yaml
+++ b/apps/applets/planifets-chatbot/staging/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base/qdrant
+  - vault-secret.yaml

--- a/apps/applets/planifets-chatbot/staging/vault-secret.yaml
+++ b/apps/applets/planifets-chatbot/staging/vault-secret.yaml
@@ -1,0 +1,19 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: VaultSecret
+metadata:
+  name: planifets-chatbot-secret
+spec:
+  refreshPeriod: 1h
+  vaultSecretDefinitions:
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: qdrant
+      path: kv/data/planifets-staging/default/chatbot/qdrant
+  output:
+    name: planifets-chatbot-secret
+    stringData:
+      qdrant_api_key: '{{ .qdrant.api_key }}'
+    type: opaque

--- a/apps/applets/planifets/base/backend/deployment.yaml
+++ b/apps/applets/planifets/base/backend/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: planifets-backend
   annotations:
-    kube-score/ignore: pod-networkpolicy, pod-probes
+    kube-score/ignore: pod-networkpolicy, pod-probes, container-image-tag
 spec:
   replicas: 1
   selector:
@@ -56,13 +56,17 @@ spec:
             - name: YARN_CACHE_FOLDER
               value: /tmp/.yarn-cache
           livenessProbe:
-            tcpSocket:
+            httpGet:
+              path: /api/health/live
               port: 3000
+              scheme: HTTP
             initialDelaySeconds: 30
             periodSeconds: 10
           readinessProbe:
-            tcpSocket:
+            httpGet:
+              path: /api/health/ready
               port: 3000
+              scheme: HTTP
             initialDelaySeconds: 5
             periodSeconds: 10
           resources:
@@ -77,12 +81,16 @@ spec:
           securityContext:
             runAsUser: 10001
             runAsGroup: 10001
-            readOnlyRootFilesystem: false
+            readOnlyRootFilesystem: true
           volumeMounts:
             - name: yarn-cache
               mountPath: /tmp/.yarn-cache
+            - name: tmp
+              mountPath: /tmp
       volumes:
         - name: yarn-cache
+          emptyDir: {}
+        - name: tmp
           emptyDir: {}
 ---
 apiVersion: policy/v1

--- a/apps/applets/planifets/base/frontend/deployment.yaml
+++ b/apps/applets/planifets/base/frontend/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: planifets
   annotations:
-    kube-score/ignore: pod-networkpolicy, pod-probes
+    kube-score/ignore: pod-networkpolicy, pod-probes, container-image-tag
 spec:
   replicas: 2
   selector:
@@ -46,8 +46,10 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 10
           readinessProbe:
-            tcpSocket:
+            httpGet:
+              path: /health
               port: 3000
+              scheme: HTTP
             initialDelaySeconds: 5
             periodSeconds: 10
           resources:

--- a/apps/applets/planifets/dev/ingress.yaml
+++ b/apps/applets/planifets/dev/ingress.yaml
@@ -1,0 +1,32 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: planifets-ingress
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    ingress.kubernetes.io/force-ssl-redirect: "true"
+    kubernetes.io/tls-acme: "true"
+spec:
+  ingressClassName: contour
+  tls:
+    - secretName: planifets-dev-tls
+      hosts:
+        - planifets.dev.cedille.club
+  rules:
+    - host: planifets.dev.cedille.club
+      http:
+        paths:
+          - pathType: Prefix
+            path: /
+            backend:
+              service:
+                name: planifets-service
+                port:
+                  number: 3000
+          - pathType: Prefix
+            path: /api
+            backend:
+              service:
+                name: planifets-backend-service
+                port:
+                  number: 3000

--- a/apps/applets/planifets/dev/kustomization.yaml
+++ b/apps/applets/planifets/dev/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base/frontend
+  - ../base/backend
+  - ingress.yaml
+  - vault-secret.yaml
+
+patches:
+  - path: patch-replicas.yaml

--- a/apps/applets/planifets/dev/patch-replicas.yaml
+++ b/apps/applets/planifets/dev/patch-replicas.yaml
@@ -1,0 +1,14 @@
+# Scale down to 1 replica in dev to save resources
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: planifets
+spec:
+  replicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: planifets-backend
+spec:
+  replicas: 1

--- a/apps/applets/planifets/dev/vault-secret.yaml
+++ b/apps/applets/planifets/dev/vault-secret.yaml
@@ -1,0 +1,69 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: VaultSecret
+metadata:
+  name: planifets-frontend-secret
+spec:
+  refreshPeriod: 1h
+  vaultSecretDefinitions:
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: frontend
+      path: kv/data/planifets-dev/default/frontend
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: backend
+      path: kv/data/planifets-dev/default/backend
+  output:
+    name: planifets-frontend-secret
+    stringData:
+      umami_website_id: '{{ .frontend.umami_website_id }}'
+      posthog_project_token: '{{ .backend.posthog_project_token }}'
+    type: opaque
+---
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: VaultSecret
+metadata:
+  name: planifets-secret
+spec:
+  refreshPeriod: 1h
+  vaultSecretDefinitions:
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: backend
+      path: kv/data/planifets-dev/default/backend
+  output:
+    name: planifets-secret
+    stringData:
+      db_url: '{{ .backend.db_url }}'
+      posthog_api_key: '{{ .backend.posthog_api_key }}'
+    type: opaque
+---
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: VaultSecret
+metadata:
+  name: cnpg-vault-secret
+spec:
+  refreshPeriod: 1h
+  vaultSecretDefinitions:
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: db
+      path: kv/data/planifets-dev/default/cnpg
+  output:
+    name: cnpg-secret
+    stringData:
+      username: '{{ .db.username }}'
+      password: '{{ .db.password }}'
+    type: kubernetes.io/basic-auth

--- a/apps/applets/planifets/planifets.argoapp.yaml
+++ b/apps/applets/planifets/planifets.argoapp.yaml
@@ -9,7 +9,7 @@ metadata:
     argocd-image-updater.argoproj.io/website.update-strategy: digest
     argocd-image-updater.argoproj.io/backend.update-strategy: digest
 spec:
-  project: k8s-cedille-production-v2
+  project: applets
   destination:
     server: https://cedille.kubernetes.omni.siderolabs.io?cluster=k8s-cedille-production-v2
     namespace: planifets
@@ -20,7 +20,9 @@ spec:
   syncPolicy:
     syncOptions:
       - CreateNamespace=true
-      - PruneLast=true
+    automated:
+      selfHeal: true
+      prune: true
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application

--- a/apps/applets/planifets/staging/ingress.yaml
+++ b/apps/applets/planifets/staging/ingress.yaml
@@ -1,0 +1,32 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: planifets-ingress
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    ingress.kubernetes.io/force-ssl-redirect: "true"
+    kubernetes.io/tls-acme: "true"
+spec:
+  ingressClassName: contour
+  tls:
+    - secretName: planifets-staging-tls
+      hosts:
+        - planifets.staging.cedille.club
+  rules:
+    - host: planifets.staging.cedille.club
+      http:
+        paths:
+          - pathType: Prefix
+            path: /
+            backend:
+              service:
+                name: planifets-service
+                port:
+                  number: 3000
+          - pathType: Prefix
+            path: /api
+            backend:
+              service:
+                name: planifets-backend-service
+                port:
+                  number: 3000

--- a/apps/applets/planifets/staging/kustomization.yaml
+++ b/apps/applets/planifets/staging/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base/frontend
+  - ../base/backend
+  - ingress.yaml
+  - vault-secret.yaml

--- a/apps/applets/planifets/staging/patch-replicas.yaml
+++ b/apps/applets/planifets/staging/patch-replicas.yaml
@@ -1,0 +1,14 @@
+# Scale down to 1 replica in dev to save resources
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: planifets
+spec:
+  replicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: planifets-backend
+spec:
+  replicas: 1

--- a/apps/applets/planifets/staging/vault-secret.yaml
+++ b/apps/applets/planifets/staging/vault-secret.yaml
@@ -1,0 +1,69 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: VaultSecret
+metadata:
+  name: planifets-frontend-secret
+spec:
+  refreshPeriod: 1h
+  vaultSecretDefinitions:
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: frontend
+      path: kv/data/planifets-staging/default/frontend
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: backend
+      path: kv/data/planifets-staging/default/backend
+  output:
+    name: planifets-frontend-secret
+    stringData:
+      umami_website_id: '{{ .frontend.umami_website_id }}'
+      posthog_project_token: '{{ .backend.posthog_project_token }}'
+    type: opaque
+---
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: VaultSecret
+metadata:
+  name: planifets-secret
+spec:
+  refreshPeriod: 1h
+  vaultSecretDefinitions:
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: backend
+      path: kv/data/planifets-staging/default/backend
+  output:
+    name: planifets-secret
+    stringData:
+      db_url: '{{ .backend.db_url }}'
+      posthog_api_key: '{{ .backend.posthog_api_key }}'
+    type: opaque
+---
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: VaultSecret
+metadata:
+  name: cnpg-vault-secret
+spec:
+  refreshPeriod: 1h
+  vaultSecretDefinitions:
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: db
+      path: kv/data/planifets-staging/default/cnpg
+  output:
+    name: cnpg-secret
+    stringData:
+      username: '{{ .db.username }}'
+      password: '{{ .db.password }}'
+    type: kubernetes.io/basic-auth


### PR DESCRIPTION
This pull request introduces a new GitOps deployment for the `planifets-chatbot` Qdrant service and refactors the `planifets` applet manifests to support multi-environment (dev, staging, prod) deployment using Kustomize overlays and improved Kubernetes best practices. It also enhances security, readiness/liveness probes, and secret management with HashiCorp Vault integration. The following are the most important changes:

---

**1. Introduction of Qdrant Service for `planifets-chatbot`**

- Added a new ArgoCD-managed applet for `planifets-chatbot` focused solely on deploying the Qdrant vector database, with clear separation of environments and secret management via Vault. (`README.md`, `base/qdrant/*`, `dev/`, `staging/`, `prod/`, `planifets-chatbot.argoapp.yaml`) [[1]](diffhunk://#diff-da3ae9e573f19ccc9566f9f462161e8bf84ba2a2175beb10c63e5f5a6c3fa9d7R1-R75) [[2]](diffhunk://#diff-82856f3d55f9d65805cc8d2dfed3ba783f9fc29bcad855bf8a25ed57f47e7c60R1-R6) [[3]](diffhunk://#diff-9d94eca7c8d346e8ce9fb7116cef8af08a4f2dbb61f5ff8bcf597ae09758b010R1-R18) [[4]](diffhunk://#diff-1d195e2747b0fb6188f5f7cf796e753cc1601ad6ff4b42d9deb99c6b5c541234R1-R75) [[5]](diffhunk://#diff-fbc6ef2a2ed77d81df9e02369cf3f587ad8ea3c50a7dc3b7e78e130b740deca3R1-R6) [[6]](diffhunk://#diff-fcf5a91612d60fc78a91bbb9e36b0364dc4fb691bf387e9fd3e17af4e29a18b0R1-R19) [[7]](diffhunk://#diff-d0fbec6b5567a5afe2da3c4915bfa614dbc3e782400d429a762b99f1a1563e37R1-R19) [[8]](diffhunk://#diff-8432110136a5f95a78f026b31853dc3f4e6fbaacb0319d0d54dcc19522c392ffR1-R41)

---

**2. Refactoring and Hardened Deployment for `planifets` Applet**

- Migrated `planifets` to a multi-environment Kustomize structure, with overlays for dev and staging, and corresponding ArgoCD applications. (`planifets.argoapp.yaml`, `dev/`, `staging/`) [[1]](diffhunk://#diff-150869cf5c10e956a59c72be01690b8872a65e7ccd3eb30d5803400613fa77c6R26-R73) [[2]](diffhunk://#diff-05d565704a33dc73a45a2d645a65b17b87a706b28955302bd1f92935a0125423R1-R11) [[3]](diffhunk://#diff-86f07f01fe59440e93d3d86a08f5b930527215d557e9d9e2376ceb8193d77875R1-R8)
- Added dedicated Ingress resources for dev and staging, with TLS and path-based routing for frontend and backend. (`dev/ingress.yaml`, `staging/ingress.yaml`) [[1]](diffhunk://#diff-1089ca1f51da0e50bfbf9b071fb0fc0708acf90dd27a6bfcbc99287ed6e9685eR1-R32) [[2]](diffhunk://#diff-9d79807cd8e1ceff54c7c505a138784804ef479cf80410bface71acf67296989R1-R32)
- Introduced environment-specific scaling patches to optimize resource usage in non-prod environments. (`dev/patch-replicas.yaml`, `staging/patch-replicas.yaml`)

---

**3. Improved Security and Probes**

- Set `readOnlyRootFilesystem: true` for backend and frontend containers for better security; added `/tmp` volume and mount for compatibility. (`base/backend/deployment.yaml`, `base/frontend/deployment.yaml`) [[1]](diffhunk://#diff-039c6d7f31ed0a0bd05e79f9815a89648b7544be735f2881ce32d5728e881affL80-R94) [[2]](diffhunk://#diff-75568b312f57e3adfcd6d42dabe2da0e715726276d6d06cc5fba6f733a8b01eaL6-R6)
- Switched liveness and readiness probes from TCP to HTTP checks with appropriate endpoints, improving health monitoring. (`base/backend/deployment.yaml`, `base/frontend/deployment.yaml`) [[1]](diffhunk://#diff-039c6d7f31ed0a0bd05e79f9815a89648b7544be735f2881ce32d5728e881affL59-R69) [[2]](diffhunk://#diff-75568b312f57e3adfcd6d42dabe2da0e715726276d6d06cc5fba6f733a8b01eaL49-R52)
- Added `container-image-tag` to kube-score ignore annotations for both backend and frontend deployments. [[1]](diffhunk://#diff-039c6d7f31ed0a0bd05e79f9815a89648b7544be735f2881ce32d5728e881affL6-R6) [[2]](diffhunk://#diff-75568b312f57e3adfcd6d42dabe2da0e715726276d6d06cc5fba6f733a8b01eaL6-R6)

---

**4. Vault-based Secret Management**

- Introduced VaultSecret resources for both `planifets` and `planifets-chatbot` to securely inject secrets into Kubernetes, with per-environment paths and keys. (`dev/vault-secret.yaml`, `staging/vault-secret.yaml`, `planifets-chatbot/dev/vault-secret.yaml`, `planifets-chatbot/staging/vault-secret.yaml`) [[1]](diffhunk://#diff-83f069fc2ed105f531d5b581617774d0e5e4c127423135bc63e573a1071b0583R1-R69) [[2]](diffhunk://#diff-fcf5a91612d60fc78a91bbb9e36b0364dc4fb691bf387e9fd3e17af4e29a18b0R1-R19) [[3]](diffhunk://#diff-d0fbec6b5567a5afe2da3c4915bfa614dbc3e782400d429a762b99f1a1563e37R1-R19)

---

These changes collectively improve the maintainability, security, and scalability of the `planifets` and `planifets-chatbot` deployments, and lay the groundwork for robust multi-environment operations.