### PR TITLE
Create a WordPress website for mon-club

### DIFF
--- a/apps/mon-club/wordpress/mon-club-wordpress.argoapp.yaml
+++ b/apps/mon-club/wordpress/mon-club-wordpress.argoapp.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: mon-club-wordpress
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  project: k8s-cedille-production-v2
+  destination:
+    server: https://cedille.kubernetes.omni.siderolabs.io?cluster=k8s-cedille-production-v2
+    namespace: mon-club-wordpress
+  source:
+    repoURL: https://github.com/ClubCedille/k8s-cedille-production-v2
+    path: apps/mon-club/wordpress/prod
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      selfHeal: true
+      prune: true

--- a/apps/mon-club/wordpress/prod/configMap.yaml
+++ b/apps/mon-club/wordpress/prod/configMap.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: wordpress-config
+data:
+  WORDPRESS_DB_HOST: "mysql:3306"
+  WORDPRESS_DB_NAME: "wordpress"
+  WORDPRESS_DB_USER: "wordpress"
+  WORDPRESS_HOME: "https://mon-club.prodv2.cedille.club"
+  WORDPRESS_SITEURL: "https://mon-club.prodv2.cedille.club"
+  WORDPRESS_SITE_TITLE: "mon-club"
+  WORDPRESS_ADMIN_USER: "admin"
+  WORDPRESS_ADMIN_EMAIL: "admin@mon-club.prodv2.cedille.club"
+  WORDPRESS_CONFIG_EXTRA: |-
+    if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
+      $_SERVER['HTTPS'] = 'on';
+    }
+    define('WP_HOME', getenv('WORDPRESS_HOME'));
+    define('WP_SITEURL', getenv('WORDPRESS_SITEURL'));
+  MYSQL_DATABASE: "wordpress"
+  MYSQL_USER: "wordpress"

--- a/apps/mon-club/wordpress/prod/ingress.yaml
+++ b/apps/mon-club/wordpress/prod/ingress.yaml
@@ -1,0 +1,33 @@
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: wordpress
+spec:
+  virtualhost:
+    fqdn: mon-club.prodv2.cedille.club
+    tls:
+      secretName: wordpress-tls
+      minimumProtocolVersion: "1.2"
+  routes:
+    - conditions:
+        - prefix: /
+      services:
+        - name: wordpress
+          port: 80
+      requestHeadersPolicy:
+        set:
+          - name: X-Forwarded-Proto
+            value: https
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wordpress-tls
+spec:
+  secretName: wordpress-tls
+  issuerRef:
+    name: letsencrypt-http
+    kind: ClusterIssuer
+  commonName: mon-club.prodv2.cedille.club
+  dnsNames:
+    - mon-club.prodv2.cedille.club

--- a/apps/mon-club/wordpress/prod/kustomization.yaml
+++ b/apps/mon-club/wordpress/prod/kustomization.yaml
@@ -1,0 +1,45 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: mon-club-wordpress
+
+resources:
+  - ../../../../bases/wordpress
+  - configMap.yaml
+  - ingress.yaml
+  - vault-secret.yaml
+
+patches:
+  - target:
+      kind: RandomSecret
+    patch: |-
+      - op: replace
+        path: /spec/path
+        value: kv/data/mon-club-wordpress/default/wordpress
+  - target:
+      kind: Deployment
+      name: wordpress
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/image
+        value: "wordpress:6.8.3-php8.2-apache"
+      - op: replace
+        path: /spec/template/spec/initContainers/0/image
+        value: "wordpress:cli-php8.2"
+  - target:
+      kind: StatefulSet
+      name: mysql
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/image
+        value: "mysql:8.4"
+      - op: replace
+        path: /spec/volumeClaimTemplates/0/spec/resources/requests/storage
+        value: "10Gi"
+  - target:
+      kind: PersistentVolumeClaim
+      name: wordpress-content-pvc
+    patch: |-
+      - op: replace
+        path: /spec/resources/requests/storage
+        value: "10Gi"

--- a/apps/mon-club/wordpress/prod/vault-secret.yaml
+++ b/apps/mon-club/wordpress/prod/vault-secret.yaml
@@ -1,0 +1,100 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: VaultSecret
+metadata:
+  name: wordpress-secret-sync
+spec:
+  refreshPeriod: 1h
+  vaultSecretDefinitions:
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: admin_password
+      path: kv/data/mon-club-wordpress/default/wordpress/wordpress-admin-password
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: db_password
+      path: kv/data/mon-club-wordpress/default/wordpress/wordpress-db-password
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: db_root_password
+      path: kv/data/mon-club-wordpress/default/wordpress/wordpress-db-root-password
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: auth_key
+      path: kv/data/mon-club-wordpress/default/wordpress/wordpress-auth-key
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: secure_auth_key
+      path: kv/data/mon-club-wordpress/default/wordpress/wordpress-secure-auth-key
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: logged_in_key
+      path: kv/data/mon-club-wordpress/default/wordpress/wordpress-logged-in-key
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: nonce_key
+      path: kv/data/mon-club-wordpress/default/wordpress/wordpress-nonce-key
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: auth_salt
+      path: kv/data/mon-club-wordpress/default/wordpress/wordpress-auth-salt
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: secure_auth_salt
+      path: kv/data/mon-club-wordpress/default/wordpress/wordpress-secure-auth-salt
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: logged_in_salt
+      path: kv/data/mon-club-wordpress/default/wordpress/wordpress-logged-in-salt
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: nonce_salt
+      path: kv/data/mon-club-wordpress/default/wordpress/wordpress-nonce-salt
+  output:
+    name: wordpress-secret
+    stringData:
+      WORDPRESS_ADMIN_PASSWORD: "{{ .admin_password.password }}"
+      MYSQL_PASSWORD: "{{ .db_password.password }}"
+      MYSQL_ROOT_PASSWORD: "{{ .db_root_password.password }}"
+      WORDPRESS_DB_PASSWORD: "{{ .db_password.password }}"
+      WORDPRESS_AUTH_KEY: "{{ .auth_key.password }}"
+      WORDPRESS_SECURE_AUTH_KEY: "{{ .secure_auth_key.password }}"
+      WORDPRESS_LOGGED_IN_KEY: "{{ .logged_in_key.password }}"
+      WORDPRESS_NONCE_KEY: "{{ .nonce_key.password }}"
+      WORDPRESS_AUTH_SALT: "{{ .auth_salt.password }}"
+      WORDPRESS_SECURE_AUTH_SALT: "{{ .secure_auth_salt.password }}"
+      WORDPRESS_LOGGED_IN_SALT: "{{ .logged_in_salt.password }}"
+      WORDPRESS_NONCE_SALT: "{{ .nonce_salt.password }}"
+    type: Opaque


### PR DESCRIPTION
Nom du club: mon-club
Domaine: mon-club.prodv2.cedille.club
Namespace: mon-club-wordpress
Contexte: 

Le site sera disponible a https://mon-club.prodv2.cedille.club apres la synchronisation Argo CD, la creation du certificat et la configuration DNS.

WordPress est initialise automatiquement avec l'utilisateur `admin`. Le club peut ensuite se connecter a `/wp-admin`, changer le mot de passe et personnaliser le site.

Secrets generes par Vault:
> `kv/data/mon-club-wordpress/default/wordpress`

Mot de passe admin initial:
> `kv/data/mon-club-wordpress/default/wordpress/wordpress-admin-password`