### PR TITLE
fix/PLANIFETS-139 Fix Qdrant Issues

### DIFF
--- a/apps/applets/planifets-chatbot/base/qdrant/statefulset.yaml
+++ b/apps/applets/planifets-chatbot/base/qdrant/statefulset.yaml
@@ -24,6 +24,7 @@ spec:
         - name: qdrant
           image: qdrant/qdrant:latest
           imagePullPolicy: Always
+          workingDir: /tmp
           ports:
             - containerPort: 6333
               name: http
@@ -37,6 +38,8 @@ spec:
                   key: qdrant_api_key
             - name: QDRANT__STORAGE__SNAPSHOTS_PATH
               value: /qdrant/storage/snapshots
+            - name: QDRANT__TELEMETRY_DISABLED
+              value: "true"
           livenessProbe:
             tcpSocket:
               port: 6333

--- a/apps/applets/planifets/base/backend/deployment.yaml
+++ b/apps/applets/planifets/base/backend/deployment.yaml
@@ -59,6 +59,13 @@ spec:
               value: /transformers-cache
             - name: EMBEDDING_ORT_THREADS
               value: "2"
+            - name: QDRANT_URL
+              value: "http://planifets-chatbot-qdrant:6333"
+            - name: QDRANT_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: planifets-chatbot-secret
+                  key: qdrant_api_key
           livenessProbe:
             httpGet:
               path: /api/health


### PR DESCRIPTION
**Décrire le pull-request**
Correction des warnings Qdrant et ajout de la configuration manquante pour connecter le backend à Qdrant en cluster.

- `StatefulSet` Qdrant : Ajout de `workingDir: /tmp` pour résoudre le warning Read-only file system lors de la création de `.qdrant-initialized`, et désactivation de la télémétrie (`QDRANT__TELEMETRY_DISABLED`) pour éliminer les erreurs de connexion à `telemetry.qdrant.io`.
- Deployment backend : Ajout des variables d'environnement `QDRANT_URL` et `QDRANT_API_KEY` (référençant le secret `planifets-chatbot-secret` déjà existant dans le même namespace) pour permettre la connexion au Qdrant du cluster.

**Vérification**
Veuillez cocher les cases suivantes pour confirmer que vous avez effectué les vérifications nécessaires avant de soumettre le pull-request :

- [x] J'ai vérifié que le code fonctionne correctement.
- [x] J'ai vérifié que le code respecte l'architecture du projet.

**Documentation**
- [x] J'ai mis à jour la documentation si nécessaire sinon j'ai ouvert un issue pour la mettre à jour.