### PR TITLE
Create a GRAV website for grav-smoke-test

### DIFF
--- a/apps/grav-smoke-test/grav/grav-smoke-test-grav.argoapp.yaml
+++ b/apps/grav-smoke-test/grav/grav-smoke-test-grav.argoapp.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: grav-smoke-test-grav
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+    argocd-image-updater.argoproj.io/image-list: website=ghcr.io/clubcedille/grav:latest
+    argocd-image-updater.argoproj.io/website.update-strategy: digest
+spec:
+  project: k8s-cedille-production-v2
+  destination:
+    server: https://cedille.kubernetes.omni.siderolabs.io?cluster=k8s-cedille-production-v2
+    namespace: grav-smoke-test-grav
+  source:
+    repoURL: https://github.com/ClubCedille/k8s-cedille-production-v2
+    path: apps/grav-smoke-test/grav/prod
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      selfHeal: true
+      prune: true

--- a/apps/grav-smoke-test/grav/prod/kustomization.yaml
+++ b/apps/grav-smoke-test/grav/prod/kustomization.yaml
@@ -1,0 +1,46 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namePrefix: grav-smoke-test-
+
+resources:
+  - ../../../../bases/grav
+  - vault-secret.yaml
+
+patches:
+  - path: vault-patch.yaml
+  - target:
+      kind: HTTPProxy
+      name: grav-ingress
+    patch: |-
+      - op: replace
+        path: /spec/virtualhost/fqdn
+        value: grav-smoke-test.prodv2.cedille.club
+      - op: replace
+        path: /spec/virtualhost/tls/secretName
+        value: grav-smoke-test-grav-tls
+      - op: replace
+        path: /spec/routes/0/services/0/name
+        value: grav-smoke-test-grav
+  - target:
+      kind: Certificate
+      name: grav-tls
+    patch: |-
+      - op: replace
+        path: /spec/secretName
+        value: grav-smoke-test-grav-tls
+      - op: replace
+        path: /spec/commonName
+        value: grav-smoke-test.prodv2.cedille.club
+      - op: replace
+        path: /spec/dnsNames/0
+        value: grav-smoke-test.prodv2.cedille.club
+      - op: replace
+        path: /spec/issuerRef/name
+        value: letsencrypt-http
+  - target:
+      kind: RandomSecret
+    patch: |-
+      - op: replace
+        path: /spec/path
+        value: kv/data/grav-smoke-test-grav/default/grav

--- a/apps/grav-smoke-test/grav/prod/vault-patch.yaml
+++ b/apps/grav-smoke-test/grav/prod/vault-patch.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grav
+spec:
+  template:
+    metadata:
+      annotations:
+        vault.hashicorp.com/agent-inject: null
+        vault.hashicorp.com/role: null
+        vault.hashicorp.com/agent-inject-template-gitsync: null
+        vault.hashicorp.com/agent-inject-template-admin_pwd: null
+        vault.hashicorp.com/agent-inject-template-sre_pwd: null
+        vault.hashicorp.com/agent-inject-template-salt: null
+    spec:
+      containers:
+        - name: grav
+          volumeMounts:
+            - name: grav-vault-files
+              mountPath: /vault/secrets
+              readOnly: true
+      volumes:
+        - name: grav-vault-files
+          secret:
+            secretName: grav-smoke-test-grav-vault-files

--- a/apps/vault-gh-roles/grav-smoke-test-grav.yaml
+++ b/apps/vault-gh-roles/grav-smoke-test-grav.yaml
@@ -1,0 +1,12 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: GitHubSecretEngineRole
+metadata:
+  name: grav-smoke-test-grav
+spec:
+  authentication:
+    path: kubernetes
+    role: config-admin
+  path: github
+  repositories:
+    - grav-smoke-test.prodv2.cedille.club
+  organizationName: ClubCedille

--- a/apps/vault-gh-roles/kustomization.yaml
+++ b/apps/vault-gh-roles/kustomization.yaml
@@ -6,3 +6,4 @@ namespace: vault
 resources:
   - crabeweb-grav.yaml
   - raconteurs-grav.yaml
+  - grav-smoke-test-grav.yaml

--- a/terraform/github/apps-repos/grav-smoke-test-grav.tf
+++ b/terraform/github/apps-repos/grav-smoke-test-grav.tf
@@ -1,0 +1,49 @@
+resource "github_repository" "repo_grav-smoke-test" {
+  name = "grav-smoke-test.prodv2.cedille.club"
+  auto_init = true
+  homepage_url = "https://grav-smoke-test.prodv2.cedille.club"
+  description = "Site web de grav-smoke-test"
+  has_downloads = true
+  has_issues = true
+  has_projects = true
+  has_wiki = true
+  security_and_analysis {
+    secret_scanning {
+      status = "enabled"
+    }
+    secret_scanning_push_protection {
+      status = "enabled"
+    }
+  }
+  topics = [ "grav" ]
+  vulnerability_alerts = true
+  visibility = "public"
+}
+
+resource "github_repository_webhook" "webhook_grav-smoke-test" {
+  repository = github_repository.repo_grav-smoke-test.name
+
+  configuration {
+    url          = "https://grav-smoke-test.prodv2.cedille.club/_git_webhook"
+    content_type = "json"
+    insecure_ssl = false
+  }
+
+  active = true
+
+  events = ["push"]
+}
+
+resource "github_repository_dependabot_security_updates" "dependabot_grav-smoke-test" {
+  repository  = github_repository.repo_grav-smoke-test.name
+  enabled     = true
+}
+
+resource "github_repository_collaborators" "colaborators_grav-smoke-test" {
+  repository = github_repository.repo_grav-smoke-test.name
+
+  team {
+    permission = "admin"
+    team_id = "sre"
+  }
+}


### PR DESCRIPTION
Nom du club: grav-smoke-test
Domaine: grav-smoke-test.prodv2.cedille.club
Namespace: grav-smoke-test-grav
Contexte: 
ClusterIssuer: letsencrypt-http

Le site sera disponible à https://grav-smoke-test.prodv2.cedille.club après la synchronisation Argo CD, la création du certificat et la configuration DNS.

Mot de passe par defaut:
> `kubectl port-forward -n vault svc/vault-ui 8200`
> https://localhost:8200/ui/vault/secrets/kv/show/grav-smoke-test-grav/default/grav/grav-smoke-test-grav-init-pwd