### PR TITLE
fix/PLANIFETS-098 pin and deploy Qdrant in production

### DIFF
--- a/apps/applets/planifets-chatbot/README.md
+++ b/apps/applets/planifets-chatbot/README.md
@@ -8,15 +8,15 @@ Ce dossier ne contient plus une stack frontend/backend complète : il gère uniq
 
 | Composant | Image | Port | Rôle |
 |-----------|-------|------|------|
-| Qdrant | `qdrant/qdrant:latest` | `6333` / `6334` | Base vectorielle du chatbot |
+| Qdrant | `qdrant/qdrant@sha256:...` | `6333` / `6334` | Base vectorielle du chatbot |
 
 ## Environnements
 
 | Env | Namespace | ArgoCD Application | Secret Vault |
 |-----|-----------|--------------------|--------------|
-| dev | `planifets-chatbot-dev` | `planifets-chatbot-dev` | `kv/data/planifets-chatbot/dev/planifets-chatbot/qdrant` |
-| staging | `planifets-chatbot-staging` | `planifets-chatbot-staging` | `kv/data/planifets-chatbot/staging/planifets-chatbot/qdrant` |
-| prod | `planifets-chatbot` | `planifets-chatbot` | `kv/data/planifets-chatbot/default/planifets-chatbot/qdrant` |
+| dev | `planifets-dev` | `planifets-chatbot-dev` | `kv/data/planifets-dev/default/chatbot/qdrant` |
+| staging | `planifets-staging` | `planifets-chatbot-staging` | `kv/data/planifets-staging/default/chatbot/qdrant` |
+| prod | `planifets` | `planifets-chatbot` | `kv/data/planifets/default/chatbot/qdrant` |
 
 ## Structure actuelle
 
@@ -46,9 +46,9 @@ Chaque environnement crée un secret Kubernetes `planifets-chatbot-secret` conte
 
 ### Chemins Vault attendus
 
-- `dev` → `kv/data/planifets-chatbot/dev/planifets-chatbot/qdrant`
-- `staging` → `kv/data/planifets-chatbot/staging/planifets-chatbot/qdrant`
-- `prod` → `kv/data/planifets-chatbot/default/planifets-chatbot/qdrant`
+- `dev` → `kv/data/planifets-dev/default/chatbot/qdrant`
+- `staging` → `kv/data/planifets-staging/default/chatbot/qdrant`
+- `prod` → `kv/data/planifets/default/chatbot/qdrant`
 
 ## Déploiement
 
@@ -59,17 +59,17 @@ Chaque environnement crée un secret Kubernetes `planifets-chatbot-secret` conte
 ### Vérifications utiles
 
 ```bash
-kubectl get pods -n planifets-chatbot-dev
-kubectl get pods -n planifets-chatbot-staging
-kubectl get pods -n planifets-chatbot
+kubectl get pods -n planifets-dev
+kubectl get pods -n planifets-staging
+kubectl get pods -n planifets
 
-kubectl get secret -n planifets-chatbot-dev planifets-chatbot-secret
-kubectl get statefulset -n planifets-chatbot-dev planifets-chatbot-qdrant
-kubectl get svc -n planifets-chatbot-dev planifets-chatbot-qdrant
+kubectl get secret -n planifets-dev planifets-chatbot-secret
+kubectl get statefulset -n planifets-dev planifets-chatbot-qdrant
+kubectl get svc -n planifets-dev planifets-chatbot-qdrant
 ```
 
 ## Notes
 
 - Le stockage persistant Qdrant utilise un `volumeClaimTemplate` de `5Gi` avec `storageClassName: cephfs`.
 - Le service expose les ports `6333` (HTTP) et `6334` (gRPC).
-- Les trois overlays (`dev`, `staging`, `prod`) réutilisent la base `qdrant` et ne diffèrent que par leur secret Vault.
+- Chaque overlay fixe explicitement le digest Qdrant. Pour mettre Qdrant à jour, changer d'abord le digest dev, valider, puis promouvoir exactement le même digest vers staging et prod.

--- a/apps/applets/planifets-chatbot/base/qdrant/statefulset.yaml
+++ b/apps/applets/planifets-chatbot/base/qdrant/statefulset.yaml
@@ -3,7 +3,7 @@ kind: StatefulSet
 metadata:
   name: planifets-chatbot-qdrant
   annotations:
-    kube-score/ignore: pod-networkpolicy, pod-probes, container-image-tag
+    kube-score/ignore: pod-networkpolicy, pod-probes
 spec:
   serviceName: planifets-chatbot-qdrant
   replicas: 1
@@ -22,7 +22,7 @@ spec:
           emptyDir: {}
       containers:
         - name: qdrant
-          image: qdrant/qdrant:latest
+          image: qdrant/qdrant@sha256:0bd98fa7977f1e75694779359ca4e212822e5a71334e28421182f72f209d5286
           imagePullPolicy: Always
           ports:
             - containerPort: 6333
@@ -62,6 +62,7 @@ spec:
           securityContext:
             runAsUser: 10001
             runAsGroup: 10001
+            readOnlyRootFilesystem: true
           volumeMounts:
             - name: qdrant-storage
               mountPath: /qdrant/storage

--- a/apps/applets/planifets-chatbot/dev/kustomization.yaml
+++ b/apps/applets/planifets-chatbot/dev/kustomization.yaml
@@ -4,3 +4,7 @@ kind: Kustomization
 resources:
   - ../base/qdrant
   - vault-secret.yaml
+
+images:
+  - name: qdrant/qdrant
+    digest: sha256:0bd98fa7977f1e75694779359ca4e212822e5a71334e28421182f72f209d5286

--- a/apps/applets/planifets-chatbot/planifets-chatbot.argoapp.yaml
+++ b/apps/applets/planifets-chatbot/planifets-chatbot.argoapp.yaml
@@ -1,6 +1,30 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  name: planifets-chatbot
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  project: applets
+  destination:
+    server: https://cedille.kubernetes.omni.siderolabs.io?cluster=k8s-cedille-production-v2
+    namespace: planifets
+  source:
+    repoURL: https://github.com/ClubCedille/k8s-cedille-production-v2
+    path: apps/applets/planifets-chatbot/prod
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+      - PruneLast=true
+    automated:
+      selfHeal: true
+      prune: true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
   name: planifets-chatbot-staging
   namespace: argocd
   annotations:

--- a/apps/applets/planifets-chatbot/prod/kustomization.yaml
+++ b/apps/applets/planifets-chatbot/prod/kustomization.yaml
@@ -4,3 +4,7 @@ kind: Kustomization
 resources:
   - ../base/qdrant
   - vault-secret.yaml
+
+images:
+  - name: qdrant/qdrant
+    digest: sha256:0bd98fa7977f1e75694779359ca4e212822e5a71334e28421182f72f209d5286

--- a/apps/applets/planifets-chatbot/staging/kustomization.yaml
+++ b/apps/applets/planifets-chatbot/staging/kustomization.yaml
@@ -4,3 +4,7 @@ kind: Kustomization
 resources:
   - ../base/qdrant
   - vault-secret.yaml
+
+images:
+  - name: qdrant/qdrant
+    digest: sha256:0bd98fa7977f1e75694779359ca4e212822e5a71334e28421182f72f209d5286


### PR DESCRIPTION
## Summary
- add the missing production ArgoCD Application for PlanifETS Qdrant
- replace qdrant/qdrant:latest with the currently running immutable digest
- declare that digest independently in dev, staging, and prod overlays for staged upgrades
- correct namespaces and Vault paths in the Qdrant README

## Validation
- kubectl kustomize dev, staging, and prod
- every overlay renders qdrant/qdrant@sha256:0bd98fa7977f1e75694779359ca4e212822e5a71334e28421182f72f209d5286
- git diff --check

This PR does not alter secret values. Production reconciliation should occur only after confirming the existing Vault path kv/data/planifets/default/chatbot/qdrant contains api_key.