### PR TITLE
feat(planifets): source chatbot flag from Vault

### DIFF
--- a/apps/applets/planifets/base/backend/deployment.yaml
+++ b/apps/applets/planifets/base/backend/deployment.yaml
@@ -51,6 +51,12 @@ spec:
                 secretKeyRef:
                   name: planifets-secret
                   key: posthog_api_key
+            - name: CHATBOT_ENABLED
+              valueFrom:
+                secretKeyRef:
+                  name: planifets-secret
+                  key: chatbot_enabled
+                  optional: true
             - name: LOG_LEVELS
               value: "log,error,warn"
             - name: YARN_CACHE_FOLDER

--- a/apps/applets/planifets/dev/vault-secret.yaml
+++ b/apps/applets/planifets/dev/vault-secret.yaml
@@ -52,6 +52,7 @@ spec:
     stringData:
       db_url: 'postgresql://{{ .cnpg.username }}:{{ .cnpg.password }}@cnpg-rw.planifets-dev.svc.cluster.local:5432/planifetsDB?schema=public'
       posthog_api_key: '{{ .backend.posthog_api_key }}'
+      chatbot_enabled: '{{ .backend.chatbot_enabled }}'
     type: opaque
 ---
 apiVersion: redhatcop.redhat.io/v1alpha1

--- a/apps/applets/planifets/prod/vault-secret.yaml
+++ b/apps/applets/planifets/prod/vault-secret.yaml
@@ -45,4 +45,5 @@ spec:
     stringData:
       db_url: '{{ .backend.db_url }}'
       posthog_api_key: '{{ .backend.posthog_api_key }}'
+      chatbot_enabled: '{{ .backend.chatbot_enabled }}'
     type: opaque

--- a/apps/applets/planifets/staging/vault-secret.yaml
+++ b/apps/applets/planifets/staging/vault-secret.yaml
@@ -52,6 +52,7 @@ spec:
     stringData:
       db_url: 'postgresql://{{ .cnpg.username }}:{{ .cnpg.password }}@cnpg-rw.planifets-staging.svc.cluster.local:5432/planifetsDB?schema=public'
       posthog_api_key: '{{ .backend.posthog_api_key }}'
+      chatbot_enabled: '{{ .backend.chatbot_enabled }}'
     type: opaque
 ---
 apiVersion: redhatcop.redhat.io/v1alpha1


### PR DESCRIPTION
### Related issue

Related to https://github.com/ApplETS/planifETS-backend/issues/142

## Description

Makes the existing backend `CHATBOT_ENABLED` flag configurable through each environment's existing Vault backend path.

- Exposes `backend.chatbot_enabled` through the generated `planifets-secret`.
- Reads that key into the backend Deployment as `CHATBOT_ENABLED`.
- Marks the Secret reference optional so a missing key fails closed through the backend's existing `false` default instead of blocking pod startup.

Before merging, add `chatbot_enabled` to the existing backend Vault values:

| Environment | Vault path | Initial value |
| --- | --- | --- |
| Dev | `kv/data/planifets-dev/default/backend` | `true` |
| Staging | `kv/data/planifets-staging/default/planifets-staging/backend` | `false` |
| Production | `kv/data/planifets/default/planifets/planifets-backend` | `false` |

After a VaultSecret refresh, restart the backend Deployment so the process reads the updated environment variable.

## Testing

- `kubectl kustomize apps/applets/planifets/dev`
- `kubectl kustomize apps/applets/planifets/staging`
- `kubectl kustomize apps/applets/planifets/prod`
- `git diff --check`

