### PR TITLE
feat(deployment): add API keys as environment variables from Vault secrets

### DIFF
--- a/apps/applets/planifets/base/backend/deployment.yaml
+++ b/apps/applets/planifets/base/backend/deployment.yaml
@@ -66,6 +66,21 @@ spec:
                 secretKeyRef:
                   name: planifets-chatbot-secret
                   key: qdrant_api_key
+            - name: GEMINI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: planifets-secret
+                  key: gemini_api_key
+            - name: GROQ_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: planifets-secret
+                  key: groq_api_key
+            - name: NVIDIA_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: planifets-secret
+                  key: nvidia_api_key
           livenessProbe:
             httpGet:
               path: /api/health


### PR DESCRIPTION
This pull request updates the deployment configuration for the Planifets backend to add support for several new API keys. These keys are now securely injected into the environment from Kubernetes secrets, enabling integration with additional external services.

**Environment variable additions:**

* Added `GEMINI_API_KEY`, sourced from the `gemini_api_key` field in the `planifets-secret` secret.
* Added `GROQ_API_KEY`, sourced from the `groq_api_key` field in the `planifets-secret` secret.
* Added `NVIDIA_API_KEY`, sourced from the `nvidia_api_key` field in the `planifets-secret` secret.