### PR TITLE
feat(secrets): update Vault secrets to include additional API keys

### DIFF
--- a/apps/applets/planifets/base/backend/deployment.yaml
+++ b/apps/applets/planifets/base/backend/deployment.yaml
@@ -70,7 +70,7 @@ spec:
             - name: QDRANT_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: planifets-chatbot-secret
+                  name: planifets-secret
                   key: qdrant_api_key
             - name: GEMINI_API_KEY
               valueFrom:

--- a/apps/applets/planifets/dev/vault-secret.yaml
+++ b/apps/applets/planifets/dev/vault-secret.yaml
@@ -53,6 +53,10 @@ spec:
       db_url: 'postgresql://{{ .cnpg.username }}:{{ .cnpg.password }}@cnpg-rw.planifets-dev.svc.cluster.local:5432/planifetsDB?schema=public'
       posthog_api_key: '{{ .backend.posthog_api_key }}'
       chatbot_enabled: '{{ .backend.chatbot_enabled }}'
+      gemini_api_key: '{{ .backend.gemini_api_key }}'
+      groq_api_key: '{{ .backend.groq_api_key }}'
+      nvidia_api_key: '{{ .backend.nvidia_api_key }}'
+      qdrant_api_key: '{{ .backend.qdrant_api_key }}'
     type: opaque
 ---
 apiVersion: redhatcop.redhat.io/v1alpha1

--- a/apps/applets/planifets/prod/vault-secret.yaml
+++ b/apps/applets/planifets/prod/vault-secret.yaml
@@ -46,4 +46,8 @@ spec:
       db_url: '{{ .backend.db_url }}'
       posthog_api_key: '{{ .backend.posthog_api_key }}'
       chatbot_enabled: '{{ .backend.chatbot_enabled }}'
+      gemini_api_key: '{{ .backend.gemini_api_key }}'
+      groq_api_key: '{{ .backend.groq_api_key }}'
+      nvidia_api_key: '{{ .backend.nvidia_api_key }}'
+      qdrant_api_key: '{{ .backend.qdrant_api_key }}'
     type: opaque

--- a/apps/applets/planifets/staging/vault-secret.yaml
+++ b/apps/applets/planifets/staging/vault-secret.yaml
@@ -53,6 +53,10 @@ spec:
       db_url: 'postgresql://{{ .cnpg.username }}:{{ .cnpg.password }}@cnpg-rw.planifets-staging.svc.cluster.local:5432/planifetsDB?schema=public'
       posthog_api_key: '{{ .backend.posthog_api_key }}'
       chatbot_enabled: '{{ .backend.chatbot_enabled }}'
+      gemini_api_key: '{{ .backend.gemini_api_key }}'
+      groq_api_key: '{{ .backend.groq_api_key }}'
+      nvidia_api_key: '{{ .backend.nvidia_api_key }}'
+      qdrant_api_key: '{{ .backend.qdrant_api_key }}'
     type: opaque
 ---
 apiVersion: redhatcop.redhat.io/v1alpha1


### PR DESCRIPTION
This pull request updates secret management for the Planifets applets by ensuring that all necessary API keys are included in the Vault secrets for each environment and by standardizing the referenced secret name for the Qdrant API key.

**Secret management improvements:**

* Added `gemini_api_key`, `groq_api_key`, `nvidia_api_key`, and `qdrant_api_key` to the Vault secrets in `dev`, `staging`, and `prod` environments to ensure all required API keys are present. [[1]](diffhunk://#diff-83f069fc2ed105f531d5b581617774d0e5e4c127423135bc63e573a1071b0583R56-R59) [[2]](diffhunk://#diff-c91ceb2ff32b0472d15bc1cc58d13f98bbaf66dad3e21981bb04db141cd3dd14R56-R59) [[3]](diffhunk://#diff-e7cf0bbcbcbd90e81599ebc6c83584f787e4004567a05f3dcb268a0e3b8f686aR49-R52). This should have been included in the previous PR but was omitted by error.
* Updated the `qdrant_api_key` secret reference in the deployment manifest to use the standardized secret name `planifets-secret` instead of `planifets-chatbot-secret`.