### PR TITLE
fix(secrets): fix invalid path for prod qdrant api key

### DIFF
--- a/apps/applets/planifets-chatbot/README.md
+++ b/apps/applets/planifets-chatbot/README.md
@@ -16,7 +16,7 @@ Ce dossier ne contient plus une stack frontend/backend complète : il gère uniq
 |-----|-----------|--------------------|--------------|
 | dev | `planifets-dev` | `planifets-chatbot-dev` | `kv/data/planifets-dev/default/chatbot/qdrant` |
 | staging | `planifets-staging` | `planifets-chatbot-staging` | `kv/data/planifets-staging/default/chatbot/qdrant` |
-| prod | `planifets` | `planifets-chatbot` | `kv/data/planifets/default/chatbot/qdrant` |
+| prod | `planifets` | `planifets-chatbot` | `kv/data/planifets/default/planifets/planifets-backend` |
 
 ## Structure actuelle
 
@@ -48,11 +48,11 @@ Chaque environnement crée un secret Kubernetes `planifets-chatbot-secret` conte
 
 - `dev` → `kv/data/planifets-dev/default/chatbot/qdrant`
 - `staging` → `kv/data/planifets-staging/default/chatbot/qdrant`
-- `prod` → `kv/data/planifets/default/chatbot/qdrant`
+- `prod` → `kv/data/planifets/default/planifets/planifets-backend`
 
 ## Déploiement
 
-1. Créer ou mettre à jour la valeur `api_key` dans le chemin Vault de l'environnement visé.
+1. Créer ou mettre à jour la valeur `api_key` pour `dev`/`staging`, ou `qdrant_api_key` pour `prod`, dans le chemin Vault de l'environnement visé.
 2. Laisser ArgoCD synchroniser l'application correspondante.
 3. Vérifier que le secret `planifets-chatbot-secret` et le StatefulSet Qdrant sont bien présents dans le namespace.
 

--- a/apps/applets/planifets-chatbot/prod/vault-secret.yaml
+++ b/apps/applets/planifets-chatbot/prod/vault-secret.yaml
@@ -11,9 +11,9 @@ spec:
         serviceAccount:
           name: default
       name: qdrant
-      path: kv/data/planifets/default/chatbot/qdrant
+      path: kv/data/planifets/default/planifets/planifets-backend
   output:
     name: planifets-chatbot-secret
     stringData:
-      qdrant_api_key: '{{ .qdrant.api_key }}'
+      qdrant_api_key: '{{ .qdrant.qdrant_api_key }}'
     type: opaque


### PR DESCRIPTION
This pull request updates the production secrets path and key naming conventions for the `planifets-chatbot` applet.

**Vault Path and Key Updates:**

* Updated the production Vault path from `kv/data/planifets/default/chatbot/qdrant` to `kv/data/planifets/default/planifets/planifets-backend` in both the documentation and the `vault-secret.yaml` manifest. [[1]](diffhunk://#diff-da3ae9e573f19ccc9566f9f462161e8bf84ba2a2175beb10c63e5f5a6c3fa9d7L19-R19) [[2]](diffhunk://#diff-da3ae9e573f19ccc9566f9f462161e8bf84ba2a2175beb10c63e5f5a6c3fa9d7L51-R55) [[3]](diffhunk://#diff-577f39789586c267b7a5f31c2fb3e178da8061edad6a6e895be8dfa1e602f224L14-R18)
* Changed the secret key used for production from `api_key` to `qdrant_api_key` to match the new Vault structure and updated the documentation to clarify which key to use for each environment. [[1]](diffhunk://#diff-da3ae9e573f19ccc9566f9f462161e8bf84ba2a2175beb10c63e5f5a6c3fa9d7L51-R55) [[2]](diffhunk://#diff-577f39789586c267b7a5f31c2fb3e178da8061edad6a6e895be8dfa1e602f224L14-R18)