### PR TITLE
fix(planifets): allow backend cache writes

### DIFF
--- a/apps/applets/planifets/base/backend/deployment.yaml
+++ b/apps/applets/planifets/base/backend/deployment.yaml
@@ -14,6 +14,9 @@ spec:
       labels:
         app: planifets-backend
     spec:
+      securityContext:
+        fsGroup: 10001
+        fsGroupChangePolicy: OnRootMismatch
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Added a `securityContext` with `fsGroup` set to `10001` and `fsGroupChangePolicy` set to `OnRootMismatch` to ensure proper file system permissions for group access within the pod.