### PR TITLE
fix(planifets): increase backend memory

### DIFF
--- a/apps/applets/planifets/base/backend/deployment.yaml
+++ b/apps/applets/planifets/base/backend/deployment.yaml
@@ -106,11 +106,11 @@ spec:
           resources:
             requests:
               cpu: 800m
-              memory: 700Mi
+              memory: 1Gi
               ephemeral-storage: 256Mi
             limits:
               cpu: 2000m
-              memory: 1Gi
+              memory: 2Gi
               ephemeral-storage: 1Gi
           securityContext:
             runAsUser: 10001


### PR DESCRIPTION
## Summary
- increase the PlanifETS backend memory request from 700Mi to 1Gi
- increase the memory limit from 1Gi to 2Gi
- prevent embedding requests from terminating the backend with OOMKilled

## Validation
- kubectl kustomize apps/applets/planifets/dev
- kubectl kustomize apps/applets/planifets/staging
- kubectl kustomize apps/applets/planifets/prod
- git diff --check