### PR TITLE
bump memory limits and request

### DIFF
--- a/apps/applets/planifets/base/backend/deployment.yaml
+++ b/apps/applets/planifets/base/backend/deployment.yaml
@@ -106,11 +106,11 @@ spec:
           resources:
             requests:
               cpu: 800m
-              memory: 3Gi
+              memory: 8Gi
               ephemeral-storage: 256Mi
             limits:
               cpu: 2000m
-              memory: 4Gi
+              memory: 10Gi
               ephemeral-storage: 1Gi
           securityContext:
             runAsUser: 10001

--- a/apps/applets/planifets/base/backend/deployment.yaml
+++ b/apps/applets/planifets/base/backend/deployment.yaml
@@ -106,11 +106,11 @@ spec:
           resources:
             requests:
               cpu: 800m
-              memory: 1Gi
+              memory: 3Gi
               ephemeral-storage: 256Mi
             limits:
               cpu: 2000m
-              memory: 2Gi
+              memory: 4Gi
               ephemeral-storage: 1Gi
           securityContext:
             runAsUser: 10001


### PR DESCRIPTION
Bumps memory request and limits due to the `bge-m3` model requiring a minimum of 3Gi to load correctly. We put a limit of 4Gi in the event of overconsumption.

This value could change if we see that this is still not sufficient.

Docs: https://bge-model.com/bge/bge_m3.html